### PR TITLE
Add loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apk --update add bash curl \
   && rm -rf /var/cache/apk/*
 
 COPY ./docker-gc /docker-gc
+COPY ./image-cleaner-loop.sh /image-cleaner-loop.sh
 
 VOLUME /var/lib/docker-gc
 
-CMD ["/docker-gc"]
+CMD ["/image-cleaner-loop.sh"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # docker-gc
 
+* [Running in a Kubernetes Cluster](#running-in-a-kubernetes-cluster)
 * [Building](#building)
 * [Installing](#installing)
 * [Usage](#usage)
@@ -23,6 +24,20 @@ still on disk.
 
 This script is intended to be run as a cron job, but you can also run it as a Docker
 container (see [below](#running-as-a-docker-container)).
+
+## Running in a Kubernetes Cluster
+
+This application would be perfect for a cron job which runs on every node, but we don't have 
+that feature yet in K8S, so we'll run it as a DaemonSet with the docker-gc script wrapped in 
+a loop. The Time between runs can be configured with the `TIME_BETWEEN_RUNS` environment var.
+
+Examples:
+```
+TIME_BETWEEN_RUNS=5s #for 5 seconds
+TIME_BETWEEN_RUNS=5m #for 5 minutes
+TIME_BETWEEN_RUNS=5h #for 5 hours
+TIME_BETWEEN_RUNS=5d #for 5 days
+```
 
 ## Building the Debian Package
 

--- a/image-cleaner-loop.sh
+++ b/image-cleaner-loop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+while true
+do
+    trap break SIGTERM
+    echo "Image-cleaner starting."
+    ./docker-gc
+    echo "Image-cleaner finished."
+    sleep ${TIME_BETWEEN_RUNS:=1d}
+done
+echo "Image-cleaner loop done."


### PR DESCRIPTION
- this version of docker-gc runs, then exits, so it's more suited to a cron job 
- kubernetes can't do cron jobs (AFAIK) that also run on every node, like a DaemonSet, so I wrapped the docker-gc script in a loop, and we can run it as a DaemonSet, with a configurable time between runs.